### PR TITLE
Fix "type instantiation is excessively deep and possibly infinite" with TS 5.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2
+
+- Mitigate TS "type instantiation is excessively deep and possibly infinite" error by simplifying the input type of `createConfiguration`.
+
 ## v0.1.1
 
 - Fix ContainerFlex horizontal margins.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@productive-codebases/react-toolbox",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@productive-codebases/react-toolbox",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@productive-codebases/build-variants": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@productive-codebases/react-toolbox",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     ":d": "npm run dev",
     "build": "CI=1 vite build",

--- a/src/libs/createToolbox/createConfiguration/index.ts
+++ b/src/libs/createToolbox/createConfiguration/index.ts
@@ -19,7 +19,7 @@ export const defaultConfiguration: IConfiguration = {
  * Create a custom React toolbox configuration from the default one.
  */
 export function createConfiguration<TConfiguration>(
-  extendedConfiguration?: PartialDeep<IConfiguration & TConfiguration>
+  extendedConfiguration?: TConfiguration
 ): Configuration<TConfiguration> {
   return deepMerge([
     defaultConfiguration,


### PR DESCRIPTION
## Description of the Change

For some reason, TS is complaining about too complex types when inferring the configuration passed to `createConfiguration`.
Removing PartialDeep fixes the issue without consequences on the usage of the function.

## Benefits

<!-- What benefits will be realized by the code change? -->

## Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

## Testing Instructions

<!-- What are the possible side-effects or negative impacts of the code change? -->

## Checklist

- [ ] Tests added
